### PR TITLE
Fix wrong fields in SSPObjUpdateInfo

### DIFF
--- a/include/FLCore/FLCoreServer.h
+++ b/include/FLCore/FLCoreServer.h
@@ -249,6 +249,19 @@ struct SLoginInfo
 	wchar_t wszAccount[36];
 };
 
+struct BestPathInfo
+{
+	int iWaypointStartIndex; //Usually starts at 1, but client can already have waypoints
+	int iDunno1; //2
+	byte bDunno2; //0
+	Vector vStartPos;
+	int iDunno3;//0
+	int iStartSysId;
+	Vector vTargetPos;
+	int iDunno4;//0
+	int iTargetSysId;
+};
+
 struct FLString
 {
 	st6::string value;

--- a/include/FLCore/FLCoreServer.h
+++ b/include/FLCore/FLCoreServer.h
@@ -182,12 +182,8 @@ struct SSPObjUpdateInfo
 	uint ship;
 	Quaternion vDir;
 	Vector vPos;
-	float fTimestamp;
+	double dTimestamp;
 	float fThrottle;
-	union {
-		float fStateValue;
-		uint iStateValue;
-	};
 	char cState;
 };
 


### PR DESCRIPTION
This seems to have been wrong since a long time and also is probably a mixup during different commits. Apparently the timestamp got changed to float (it is a double) and also the union is the actually fThrottle value.