### PR TITLE
fix: StringUtils::WildcardMatch: Fix use of wrong variable in bounds check

### DIFF
--- a/include/Utils/StringUtils.hpp
+++ b/include/Utils/StringUtils.hpp
@@ -809,7 +809,7 @@ class StringUtils
                 {
                     matched = true;
 
-                    if (patternIndex + 1 == inputView.size())
+                    if (patternIndex + 1 == patternView.size())
                     {
                         break;
                     }


### PR DESCRIPTION
This would fail when you provided e.g. input `Falcon` and pattern `Fal*`, as soon as we tried `patternView[patternIndex + 1]` below.